### PR TITLE
GoalPosition closer to the blockade

### DIFF
--- a/resource-omnibot/et/nav/mp_rocket_et_a1.gm
+++ b/resource-omnibot/et/nav/mp_rocket_et_a1.gm
@@ -283,7 +283,7 @@ global Map =
 
 global OnMapLoad = function()
 {
-	Util.SetGoalPosition( -1084, 374, -286, "PLANT_Tunnel_Blockade" );
+	Util.SetGoalPosition( -1170, 374, -286, "PLANT_Tunnel_Blockade" );
 	
 	if ( TestMapOn )
 		{ Util.AutoTestMap(); }


### PR DESCRIPTION
They plant dynamite too far from the wall, this unofficially fixes that.